### PR TITLE
feat: Add an clang-format check workflow

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,19 @@
+name: clang-format-check
+on:
+  pull_request:
+  push:
+    tags: "*"
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  Check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format check
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          clang-format-version: '18'


### PR DESCRIPTION
Use [jidicula/clang-format-action](https://github.com/jidicula/clang-format-action) to automatically check clang-format.

Note that jidicula/clang-format-action does NOT format the code - it only verifies that the repository's code follows the project's formatting conventions.