### PR TITLE
fix: Correct test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,19 +136,20 @@ jobs:
           conan build . ${{ steps.conan.outputs.args }}
 
       - name: Unix - Coverage
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.build_type == 'Debug'
         working-directory: build/${{ steps.parsed.outputs.compiler_name }}
         run: |
           ctest -C ${{ matrix.build_type }}
           gcovr -j ${{ env.nproc }} --delete --root ../../ --print-summary --xml-pretty --xml coverage.xml . --gcov-executable '${{ steps.parsed.outputs.gcov_executable }}'
 
       - name: Windows - Coverage
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && matrix.build_type == 'Debug'
         working-directory: build/${{ steps.parsed.outputs.compiler_name }}
         run: |
           OpenCppCoverage.exe --export_type cobertura:coverage.xml --cover_children -- ctest -C ${{ matrix.build_type }}
 
       - name: Publish to codecov
+        if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v4.4.0
         with:
           files: ./build/${{ steps.parsed.outputs.compiler_name }}/coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,5 +8,5 @@ comment:
      layout: "condensed_header, condensed_files, condensed_footer"
      require_changes: true
      hide_project_coverage: true
-     # comment on pr only when ci jobs that report coverage (currently 11 jobs) are all done
-     after_n_builds: 11
+     # comment on pr only when ci jobs that report coverage (currently 16 jobs) are all done
+     after_n_builds: 16

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,4 +8,5 @@ comment:
      layout: "condensed_header, condensed_files, condensed_footer"
      require_changes: true
      hide_project_coverage: true
-     after_n_builds: 32  # comment on pr only when ci jobs (currently 32 jobs) are all done
+     # comment on pr only when ci jobs that report coverage (currently 11 jobs) are all done
+     after_n_builds: 11


### PR DESCRIPTION
- Report test coverage only on debug ci jobs.
- Correct `after_n_builds` to the number of ci jobs that actually report coverage.